### PR TITLE
feat(auth): set JWT in httpOnly cookie and add profile/logout endpoints

### DIFF
--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -1,17 +1,49 @@
 const axios = require('axios');
 const asyncHandler = require('../middlewares/asyncHandler');
 
-// @desc    Login user — proxies to nr-auth service
+const authServiceUrl = () => {
+  const url = process.env.AUTH_SERVICE_URL;
+  if (!url) throw new Error('AUTH_SERVICE_URL is not configured');
+  return url;
+};
+
+const appName = () => {
+  const name = process.env.APP_NAME;
+  if (!name) throw new Error('APP_NAME is not configured');
+  return name;
+};
+
+// @desc    Authenticate user — proxies to nr-auth, sets httpOnly cookie
 // @route   POST /api/v1/auth/login
 // @access  Public
 exports.login = asyncHandler(async (req, res) => {
   try {
     const response = await axios.post(
-      `${process.env.AUTH_SERVICE_URL}/api/v1/auth/login`,
+      `${authServiceUrl()}/api/v1/auth/login`,
       req.body,
-      { headers: { 'x-app-name': process.env.APP_NAME } }
+      { headers: { 'x-app-name': appName() } }
     );
-    res.status(200).json(response.data);
+
+    const { token, user, requiresTwoFactor, tempToken } = response.data.data ?? {};
+
+    // 2FA required — forward the prompt, no cookie yet
+    if (requiresTwoFactor) {
+      return res.status(200).json({ success: true, data: { requiresTwoFactor: true, tempToken } });
+    }
+
+    if (!token || !user) {
+      return res.status(500).json({ success: false, error: 'Unexpected response from auth service' });
+    }
+
+    // Set JWT in httpOnly cookie — frontend reads session via GET /auth/profile
+    res.cookie('token', token, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 24 * 60 * 60 * 1000, // 24 hours
+    });
+
+    res.status(200).json({ success: true, user });
   } catch (err) {
     const status = err.response?.status || 500;
     const error = err.response?.data?.error || 'Login failed';
@@ -19,14 +51,31 @@ exports.login = asyncHandler(async (req, res) => {
   }
 });
 
-// @desc    Logout user
-// @route   GET /api/v1/auth/logout
+// @desc    Logout user — clears cookie and notifies nr-auth (best effort)
+// @route   POST /api/v1/auth/logout
 // @access  Private
 exports.logout = asyncHandler(async (req, res) => {
-  const token = req.cookies.token;
-  if (!token) {
-    return res.status(401).json({ success: false, error: 'Not authorized to access this route' });
+  const token = req.cookies?.token;
+
+  // Fire-and-forget logout to nr-auth — don't block or fail on error
+  if (token) {
+    axios.post(
+      `${authServiceUrl()}/api/v1/auth/logout`,
+      {},
+      { headers: { Authorization: `Bearer ${token}` } }
+    ).catch(() => {});
   }
-  res.clearCookie('token').status(200).json({ success: true, data: {} });
+
+  res.clearCookie('token');
+  res.status(200).json({ success: true, message: 'Logged out successfully' });
 });
 
+// @desc    Get current logged-in user — returns req.user set by requireAuth middleware
+// @route   GET /api/v1/auth/profile
+// @access  Private
+exports.getProfile = asyncHandler(async (req, res) => {
+  if (!req.user) {
+    return res.status(401).json({ success: false, error: 'Not authenticated' });
+  }
+  res.status(200).json({ success: true, user: req.user });
+});

--- a/src/routes/auth.routes.js
+++ b/src/routes/auth.routes.js
@@ -1,12 +1,15 @@
 const express = require('express');
 const router = express.Router();
+const { requireAuth } = require('../middlewares/auth.middleware');
 
 const {
   login,
-  logout
+  logout,
+  getProfile,
 } = require('../controllers/auth.controller');
 
 router.route('/login').post(login);
-router.route('/logout').get(logout);
+router.route('/logout').post(requireAuth, logout);
+router.route('/profile').get(requireAuth, getProfile);
 
 module.exports = router;


### PR DESCRIPTION
- Login now sets token as httpOnly cookie instead of returning it in the body
- 2FA flow forwarded without setting a cookie
- Logout changed to POST, fires best-effort notify to nr-auth, always clears cookie
- New GET /auth/profile endpoint returns current user from requireAuth middleware
- authServiceUrl() and appName() helpers throw on missing env vars